### PR TITLE
Issue 15: Restoring the Column(Split) variant

### DIFF
--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,13 +1,18 @@
 import { handleModalClick, MODAL_FRAGMENTS_PATH_SEGMENT, wrapImgsInLinks } from '../../scripts/scripts.js';
 
 export function applySplitPercentages(block) {
-  const ratios = [];
+  let ratios = [];
   for (let i = 0; i < block.classList.length; i += 1) {
     const cls = block.classList[i];
     if (cls.startsWith('split-')) {
       const varName = `--${cls}`;
       const numbers = getComputedStyle(block).getPropertyValue(varName);
-      numbers.split(':').forEach((n) => ratios.push(n));
+      if (!numbers) {
+        const clsParts = cls.split('-');
+        ratios = clsParts.slice(1).map((n) => `${n}%`);
+      } else {
+        ratios = numbers.split(':');
+      }
       break;
     }
   }


### PR DESCRIPTION
Split column variant introduced with https://github.com/hlxsites/sunstar-foundation/pull/6

A regression from the PR https://github.com/hlxsites/sunstar-foundation/pull/10 caused the Split Column feature to stop working. Restored the variant with this change.

@bosschaert Please review.

Fixes #15 

Test URLs:
- Original: https://www.sunstar-foundation.org/_drafts/shroti/testcolumns
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/_drafts/shroti/testcolumns
- After: https://issue-15-v2--sunstar-foundation--hlxsites.hlx.live/_drafts/shroti/testcolumns