### PR TITLE
Added redirection for few more URLs

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,6 +44,10 @@ const externalNavigationMappings = [
   ['/award', '/dentistry'],
   ['/oral-care', '/dentistry'],
   ['/dentistry', '/'],
+  ['/grants', '/en'],
+  ['/about-us', '/en'],
+  ['/award', '/en'],
+  ['/oral-care', '/en'],
   ['/', '/en'],
   ['/en', '/'],
 ];


### PR DESCRIPTION
Added configurations for few more URLs redirect  to open /en page in new tab when author goes from /about-us, /grants, /award & /oral-care and it's subpages . 
CC: @Dereje24 

Fixes #7 

Test URLs:
- Original: https://www.sunstar-foundation.org/about-us/message
- Before: https://main--sunstar-foundation--sunstar-foundation.hlx.live/about-us/message
- After: https://issue-7-v4--sunstar-foundation--sunstar-foundation.hlx.live/about-us/message