### PR TITLE
Dentistry breadcrumb fix

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -36,20 +36,26 @@ async function createAutoBreadcrumb(block) {
   const urlForIndex = (index) => prependSlash(pathname.split(pathSeparator).slice(1, index + 2).join(pathSeparator));
   const pathSplit = pathname.split(pathSeparator);
   const currentTitle = getMetadata('breadcrumbtitle');
+  const isDentistryPage = pathname.startsWith('/dentistry/');
 
   const breadcrumbs = [
     {
       name: placeholders.hometext,
-      url_path: `${getLanguangeSpecificPath(pathSeparator)}`,
+      url_path: isDentistryPage ? '/dentistry' : `${getLanguangeSpecificPath(pathSeparator)}`,
     },
-    ...pathSplit.slice(1, -1).map((part, index) => ({
-      // get the breadcrumb title from the index; if the index does not contain it,
-      // use the placeholders by appending '-title' to the part
-      // if no breadcrumb title is found, skip the part (empty string)
-      // eslint-disable-next-line max-len
-      name: pageIndex.find((page) => page.path === urlForIndex(index))?.breadcrumbtitle ?? (placeholders[`${part}-title`] ?? ''),
-      url_path: urlForIndex(index),
-    })),
+    ...pathSplit.slice(1, -1).map((part, index) => {
+      if (isDentistryPage && part === 'dentistry') {
+        return {};
+      }
+      return {
+        // get the breadcrumb title from the index; if the index does not contain it,
+        // use the placeholders by appending '-title' to the part
+        // if no breadcrumb title is found, skip the part (empty string)
+        // eslint-disable-next-line max-len
+        name: pageIndex.find((page) => page.path === urlForIndex(index))?.breadcrumbtitle ?? (placeholders[`${part}-title`] ?? ''),
+        url_path: urlForIndex(index),
+      };
+    }),
     {
       // get the breadcrumb title from the metadata; if the metadata does not contain it,
       // the last part of the path is used as the breadcrumb title


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes 

Test URLs:
- Original: https://www.sunstar-foundation.org/dentistry/news/20220919
- Before: https://main--sunstar-foundation--sunstar-foundation.hlx.live/dentistry/news/20220919
- After: https://breadcrumb-fix--sunstar-foundation--sunstar-foundation.hlx.live/dentistry/news/20220919

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--sunstar-foundation.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--sunstar-foundation.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
