### PR TITLE
Issue40 - YT videos playing without giving responding to the Cookie consent Manager - Modifying embed block

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,3 +1,5 @@
+.unclickable { pointer-events: none; }
+
 main .embed {
   width: unset;
   text-align: center;

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -50,7 +50,7 @@ const embedYoutube = (url, isLite) => {
       embed += url.search;
     }
     embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
-        <iframe src="https://www.youtube.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;"
+        <iframe src="https://www.youtube-nocookie.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}&enablejsapi=1` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;"
         allow="autoplay; fullscreen; picture-in-picture; encrypted-media; accelerometer; gyroscope; picture-in-picture" scrolling="no" title="Content from Youtube" loading="lazy"></iframe>
       </div>`;
   }
@@ -174,11 +174,13 @@ const loadEmbed = (block, grandChilds, link, existingClassList) => {
 };
 
 export default function decorate(block) {
+  let checkYt;
   const link = block.querySelector('a').href;
   const childDiv = block.querySelector('div');
   const grandChilds = childDiv ? childDiv.querySelectorAll('div') : [];
   const placeholder = block.querySelector('picture');
   const existingClassList = block.classList;
+  if (link) checkYt = link.includes('youtube') || link.includes('youtu.be');
   block.textContent = '';
 
   if (placeholder) {
@@ -186,6 +188,15 @@ export default function decorate(block) {
     wrapper.className = 'embed-placeholder';
     wrapper.innerHTML = '<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>';
     wrapper.prepend(placeholder);
+
+    // add unclickable behaviour to the wrapper
+    if (checkYt) wrapper.classList.add('unclickable');
+
+    // Remove unclickable behaviour to the wrapper after 3.5 seconds
+    setTimeout(() => {
+      wrapper.classList.remove('unclickable');
+    }, 3500);
+
     wrapper.addEventListener('click', () => {
       loadEmbed(block, grandChilds, link);
     });


### PR DESCRIPTION
…te YT Block

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #40 

Test URLs:
- Original: https://www.sunstar-foundation.org/_drafts/meet/episode-1-draft-v1
- Before: https://main--sunstar-foundation--sunstar-foundation.hlx.page/_drafts/meet/episode-1-draft-v1
- After: https://issue40-yt-consent-v1--sunstar-foundation--sunstar-foundation.hlx.page/_drafts/meet/episode-1-draft-v1

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--sunstar-foundation.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--sunstar-foundation.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
