### PR TITLE
Add hreflang alternatives to sitemaps

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -8,13 +8,13 @@ sitemaps:
         origin: https://www.sunstar-foundation.org
         source: /query-index.json?sheet=jp-search
         destination: /sitemap-ja.xml
-        hreflang: ja
         lastmod: YYYY-MM-DD
+        hreflang: ja
       en:
         origin: https://www.sunstar-foundation.org
         source: /query-index.json?sheet=en-search
         destination: /sitemap-en.xml
+        lastmod: YYYY-MM-DD
         hreflang: en
         alternate: /en/{path}
-        lastmod: YYYY-MM-DD
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,10 +9,12 @@ sitemaps:
         source: /query-index.json?sheet=jp-search
         destination: /sitemap-ja.xml
         hreflang: ja
+        lastmod: YYYY-MM-DD
       en:
         origin: https://www.sunstar-foundation.org
         source: /query-index.json?sheet=en-search
         destination: /sitemap-en.xml
         hreflang: en
         alternate: /en/{path}
+        lastmod: YYYY-MM-DD
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -3,18 +3,17 @@ auto-generated: true
 sitemaps:
   sunstar-foundation:
     default: ja
+    lastmod: YYYY-MM-DD
     languages:
       ja:
         origin: https://www.sunstar-foundation.org
         source: /query-index.json?sheet=jp-search
         destination: /sitemap-ja.xml
-        lastmod: YYYY-MM-DD
         hreflang: ja
       en:
         origin: https://www.sunstar-foundation.org
         source: /query-index.json?sheet=en-search
         destination: /sitemap-en.xml
-        lastmod: YYYY-MM-DD
         hreflang: en
         alternate: /en/{path}
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,8 +1,18 @@
 version: 1
 auto-generated: true
 sitemaps:
-  default:
-    origin: https://www.sunstar-foundation.org
-    source: /query-index.json
-    destination: /sitemap.xml
-    lastmod: YYYY-MM-DD
+  sunstar-foundation:
+    default: ja
+    languages:
+      ja:
+        origin: https://www.sunstar-foundation.org
+        source: /query-index.json?sheet=jp-search
+        destination: /sitemap-ja.xml
+        hreflang: ja
+      en:
+        origin: https://www.sunstar-foundation.org
+        source: /query-index.json?sheet=en-search
+        destination: /sitemap-en.xml
+        hreflang: en
+        alternate: /en/{path}
+

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.sunstar-foundation.org/sitemap.xml
+Sitemap: https://www.sunstar-foundation.org/sitemap-index.xml
 

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://www.sunstar-foundation.org/sitemap-ja.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>https://www.sunstar-foundation.org/sitemap-en.xml</loc>
+    </sitemap>
+</sitemapindex>


### PR DESCRIPTION
There are now 2 sitemaps: sitemap-ja.xml and sitemap-en.xml for the 2 languages. They are referenced into robots.txt via the new sitemap-index.xml

A sample of a generated sitemap looks like this:

```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <loc>https://www.sunstar-foundation.org/en/</loc>
    <xhtml:link rel="alternate" hreflang="ja" href="https://www.sunstar-foundation.org/"/>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar-foundation.org/en/"/>
    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.sunstar-foundation.org/"/>
  </url>
  <url>
    <loc>https://www.sunstar-foundation.org/en/about-us</loc>
    <xhtml:link rel="alternate" hreflang="ja" href="https://www.sunstar-foundation.org/about-us"/>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar-foundation.org/en/about-us"/>
    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.sunstar-foundation.org/about-us"/>
  </url>
  <url>
    <loc>https://www.sunstar-foundation.org/en/newsroom/1229</loc>
    <xhtml:link rel="alternate" hreflang="en" href="https://www.sunstar-foundation.org/en/newsroom/1229"/>
  </url>
  ...
```

Fixes: #56

Test URLs (for LHS):
- Before: https://main--sunstar-foundation--sunstar-foundation.hlx.live/en/about-us
- After: https://hreflang--sunstar-foundation--bosschaert.hlx.live/en/about-us

The new sitemaps can be found here:
- https://hreflang--sunstar-foundation--bosschaert.hlx.live/sitemap-en.xml
- https://hreflang--sunstar-foundation--bosschaert.hlx.live/sitemap-ja.xml