### PR TITLE
Update forms block to use Power Automate forms.

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -62,13 +62,13 @@ function constructPayload(form) {
 
 async function submitForm(form) {
   const payload = constructPayload(form);
-  const resp = await fetch(form.dataset.action, {
+  const resp = await fetch(submitURL, {
     method: 'POST',
     cache: 'no-cache',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ data: payload }),
+    body: JSON.stringify(payload),
   });
   await resp.text();
   sampleRUM('form:submit');
@@ -188,6 +188,7 @@ function createValidateLabel(msg) {
 
 let captchaElement;
 let userconsentElement;
+let submitURL;
 
 /**
  * id of the reCaptcha service in the user consent manager (todo: make configurable via form?)
@@ -336,6 +337,10 @@ function createCaptcha(fd) {
   return captchaElement;
 }
 
+function setSubmitURL(fd) {
+  submitURL = fd.Extra;
+}
+
 async function createForm(formURL) {
   const { pathname } = new URL(formURL);
   const resp = await fetch(pathname);
@@ -402,6 +407,9 @@ async function createForm(formURL) {
         break;
       case 'captcha':
         append(createCaptcha(fd));
+        break;
+      case 'paUrl':
+        setSubmitURL(fd);
         break;
       default:
         append(createLabel(fd));

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -1,6 +1,8 @@
 import { getLanguage, loadScript } from '../../scripts/scripts.js';
 import { sampleRUM } from '../../scripts/lib-franklin.js';
 
+let submitURL;
+
 function ensureParagraph(el) {
   // add <p> if missing
   if (!el.querySelector('p')) {
@@ -188,7 +190,6 @@ function createValidateLabel(msg) {
 
 let captchaElement;
 let userconsentElement;
-let submitURL;
 
 /**
  * id of the reCaptcha service in the user consent manager (todo: make configurable via form?)

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -807,6 +807,8 @@ export function getEnvType(hostname = window.location.hostname) {
 
     'main--sunstar-foundation--sunstar-foundation.hlx.page': 'preview',
     'main--sunstar-foundation--sunstar-foundation.hlx.live': 'live',
+    'main--sunstar-foundation--sunstar-foundation.aem.page': 'preview',
+    'main--sunstar-foundation--sunstar-foundation.aem.live': 'live',
   };
   return fqdnToEnvType[hostname] || 'dev';
 }


### PR DESCRIPTION
The URL of the Power Automate form to use for the block is stored in the paUrl field in the form definition .xlsx file.

Also: Add .aem.live and .aem.page to getEnvType()

Fixes #65

Test URLs:
- Before: https://main--sunstar-foundation--sunstar-foundation.hlx.live/en/about-us
- After: https://form-pa2--sunstar-foundation--bosschaert.aem.live/en/about-us
