### PR TITLE
Add logging to decorateDisabledButtons for debugging and improve link…

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -848,12 +848,14 @@ export function decorateRenderHints(block) {
  * @param {Element} block whose buttons are to be decorated as disabled
  */
 export function decorateDisabledButtons(block) {
+  console.log('decorateDisabledButtons');
   // get all links from contents which is text
   const anchors = block.querySelectorAll('a');
+  console.log(anchors);
   // loop through all links
   [...anchors].forEach((a) => {
     //check if link as #disabled at the end or href
-    if (a.href.endsWith("#disabled") || a.href === "") {
+    if (a.href.endsWith("disabled") || a.href === "") {
       a.classList.add('disabled', 'button', 'primary');
       a.href = 'javascript:void(0)';
       a.setAttribute('aria-disabled', 'true'); 


### PR DESCRIPTION
Test URLs:
- Original: https://www.sunstar-foundation.org/en/awards/world-dental-hygienist-awards
- Before: https://main--sunstar-foundation--sunstar-foundation.aem.live/en/awards/world-dental-hygienist-awards
- After: https://eud-table--sunstar-foundation--sunstar-foundation.aem.live/en/awards/world-dental-hygienist-awards

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--sunstar-foundation.aem.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--sunstar-foundation.aem.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
